### PR TITLE
friends_detailとfriendの新規追加失敗時の挙動

### DIFF
--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -17,9 +17,13 @@ class FriendsController < ApplicationController
 
   def create
     @friend = current_user.friends.build(friend_params)
-    @friend.save
-    flash[:success] = "人物を追加しました。"
-    redirect_to friends_url
+    if @friend.save
+      flash[:success] = "人物を追加しました。"
+      redirect_to friends_url
+    else
+      flash.now[:danger] = "失敗しました。"
+      render 'new'
+    end
   end
 
   def destroy

--- a/app/controllers/friends_details_controller.rb
+++ b/app/controllers/friends_details_controller.rb
@@ -8,9 +8,13 @@ class FriendsDetailsController < ApplicationController
 
   def create
     @friends_detail = @friend.friends_details.build(friends_detail_params)
-    @friends_detail.save
-    flash[:success] = "追加しました。"
-    redirect_to friend_path
+    if @friends_detail.save
+      flash[:success] = "追加しました。"
+      redirect_to friend_path
+    else
+      flash.now[:danger] = "失敗しました。"
+      render 'new'
+    end
   end
 
     private


### PR DESCRIPTION
friends_detailとfriendでの新規追加失敗時に、追加できてないのに「成功しました」と出てしまう現象を修正しました。

「失敗しました」のフラッシュが出るようにしています。

本当は
`
<% @friend.errors.full_messages.each do |msg| %>
`
をビューに追加して失敗理由も出してあげたかったのですが、出してくれるエラー文が英語だったため断念しました。

日本語でのエラーの出し方がわかったらまた実装したいと思います。