### PR TITLE
friends_detailのupdate

### DIFF
--- a/app/controllers/friends_details_controller.rb
+++ b/app/controllers/friends_details_controller.rb
@@ -1,7 +1,7 @@
 class FriendsDetailsController < ApplicationController
   before_action :redirect_to_login
   before_action :set_friend, only: [:create]
-  before_action :set_friends_detail, only: [:destroy]
+  before_action :set_friends_detail, only: [:edit, :update, :destroy]
 
   def new
     @friends_detail = FriendsDetail.new
@@ -15,6 +15,19 @@ class FriendsDetailsController < ApplicationController
     else
       flash.now[:danger] = "失敗しました。"
       render 'new'
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @friends_detail.update_attributes(friends_detail_params)
+      flash[:success] = "更新しました。"
+      redirect_to @friends_detail.friend
+    else
+      flash.now[:danger] = "失敗しました。"
+      render 'edit'
     end
   end
 

--- a/app/views/friends/show.html.erb
+++ b/app/views/friends/show.html.erb
@@ -13,6 +13,7 @@
       <div>
         <%= friends_detail.feature %>
         <%= friends_detail.content %>
+        <%= link_to '編集', edit_friends_detail_path(friends_detail) %>
         <%= link_to '削除', friends_detail, method: :delete, data: { confirm: '本当に削除してもよろしいですか？' } %>
       </div>
     <% end %>

--- a/app/views/friends_details/edit.html.erb
+++ b/app/views/friends_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @friends_detail, url: {controller: 'friends_details', action: 'edit' }, local: true) do |f| %>
+<%= form_with(model: @friends_detail, local: true) do |f| %>
   <div class="form_wrapper">
     <div class="input_item">
       <%= f.label :"feature", {class: 'label_cus'} %>

--- a/app/views/friends_details/edit.html.erb
+++ b/app/views/friends_details/edit.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(model: @friends_detail, url: {controller: 'friends_details', action: 'edit' }, local: true) do |f| %>
+  <div class="form_wrapper">
+    <div class="input_item">
+      <%= f.label :"feature", {class: 'label_cus'} %>
+      <%= f.text_field :feature, {class: 'input_cus'} %>
+    </div>
+    <div class="input_item">
+      <%= f.label :"content", {class: 'label_cus'} %>
+      <%= f.text_field :content, {class: 'input_cus'} %>
+    </div>
+    <!-- フォームのボトム部分 -->
+    <div class="form_bottom">
+      <%= f.submit "更新する", class: "btn btn_cus" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,7 +15,7 @@
             <%= @user.email %>
           <a>
           <div>
-            <%= link_to '編集', edit_user_url %>
+            <%= link_to '編集', edit_user_path %>
           </div>
         <% else %>
           <a>表示できません。</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   get '/friends/:id/new', to: 'friends_details#new', as: 'new_friends_detail'
   post '/friends/:id/new', to: 'friends_details#create'
+  patch '/friends_details/:id/edit', to: 'friends_details#update'
 
   resources :users
   resources :friends

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
 
   get '/friends/:id/new', to: 'friends_details#new', as: 'new_friends_detail'
   post '/friends/:id/new', to: 'friends_details#create'
-  patch '/friends_details/:id/edit', to: 'friends_details#update'
 
   resources :users
   resources :friends


### PR DESCRIPTION
friends_detailのupdate機能
https://github.com/kenkeeeenbbt/memopy/issues/51
に取り組みました。

/friends_details/:idパスにpatchメソッドを送る方法がわからなかったので、代替策としてルーティングに
`patch '/friends_details/:id/edit', to: 'friends_details#update'`
を追加しています。

ついでにapp/views/users/show.html.erb のurlをpathに変えてあります。