### PR TITLE
友達リスト＞友達の名前編集画面で、フォームに空白で入力した時に起こるレイアウトの崩れを解消しました。

### DIFF
--- a/app/views/friends/edit.html.erb
+++ b/app/views/friends/edit.html.erb
@@ -9,8 +9,12 @@
         <!-- フォームのメイン部分 -->
         <div class="input_items">
           <div class="input_item">
-            <%= f.label :"お名前", class: 'label_cus' %>
-            <%= f.text_field :name, class: 'input_cus' %>
+            <div class="label_wrapper">
+              <%= f.label :"お名前", class: 'label_cus' %>
+            </div>
+            <div class="field">
+              <%= f.text_field :name, class: 'input_cus' %>
+            </div>
           </div>
         </div>
         <div class=form_bottom>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -19,7 +19,8 @@
               <span class='label_required'>必須</span>
             </div>
             <div class="field">
-              <div class="fake" id="fake">example@memopy.com</div>
+              <%# プレースホルダーフェイク機能を凍結中 %>
+              <%# <div class="fake" id="fake">example@memopy.com</div> %>
               <%= f.email_field :email, class: 'input_cus' %>
             </div>
           </div>
@@ -30,7 +31,8 @@
               <span class='label_required'>必須</span>
             </div>
             <div class="field">
-              <div class="fake" id="fake">半角英数で入力</div>
+              <%# プレースホルダーフェイク機能を凍結中 %>
+              <%# <div class="fake" id="fake">半角英数で入力</div> %>
               <%= f.password_field :password,class: 'input_cus' %>
             </div>
           </div>


### PR DESCRIPTION
・現在のプレースホルダーフェイク機能が、入力情報を記憶している機能と相性が悪かったため、一部凍結しました。

・タイトルの通りですが、フォームに空白で送信時に起こるレイアウトの崩れを解消しました。