### PR TITLE
friends-detailの更新、追加フォームのデザイン崩れ対策

### DIFF
--- a/app/assets/stylesheets/friends.css
+++ b/app/assets/stylesheets/friends.css
@@ -314,7 +314,7 @@
 
 /* 入力フォーム テキスト用 */
 .detail-input-cus {
-  width: calc(100% - 210px);
+  width: 320px;
   -webkit-appearance: none;
   border: 1px solid rgba(82, 78, 69, 0.5019607843137255);
   border-radius: 5px;
@@ -393,7 +393,7 @@
   }
   /* 入力フォーム テキスト用 */
   .detail-input-cus {
-    width: auto;
+    width: 280px;
     -webkit-appearance: none;
   }
   /* スマホサイズ時に、改行が行われるCSSクラスを実行 */

--- a/app/views/friends_details/edit.html.erb
+++ b/app/views/friends_details/edit.html.erb
@@ -11,14 +11,16 @@
         <div class="detail-input-items">
           <!-- 名前の入力アイテム -->
           <div class="detail-input-item">
-            <%#<%= f.label :"情報名", {class: 'detail-label_cus'} %>
             <p>情報名</p><br>
-            <%= f.text_field :feature, {class: 'detail-input-cus'} %>
+            <div class="detail-field">
+              <%= f.text_area :feature, {class: 'detail-input-cus'} %>
+            </div>
           </div>
           <div class="detail-input-item">
-            <%#<%= f.label :"詳細内容", {class: 'detail-label_cus'} %>
             <p>詳細内容</p>
-            <%= f.text_area :content, {class: 'detail-input-cus'} %>
+            <div class="detail-field">
+              <%= f.text_area :content, {class: 'detail-input-cus'} %>
+            </div>
           </div>
         </div>
         <!-- フォームのボトム部分 -->

--- a/app/views/friends_details/new.html.erb
+++ b/app/views/friends_details/new.html.erb
@@ -12,11 +12,15 @@
           <!-- 名前の入力アイテム -->
           <div class="detail-input-item">
             <p>情報名</p><br>
-            <%= f.text_field :feature, {class: 'detail-input-cus'} %>
+            <div class="detail-field">
+              <%= f.text_area :feature, {class: 'detail-input-cus'} %>
+            </div>
           </div>
           <div class="detail-input-item">
             <p>詳細内容</p>
-            <%= f.text_area :content, {class: 'detail-input-cus'} %>
+            <div class="detail-field">
+              <%= f.text_area :content, {class: 'detail-input-cus'} %>
+            </div>
           </div>
         </div>
         <!-- フォームのボトム部分 -->


### PR DESCRIPTION
フォーム内を空の状態で更新や追加をすると、
入力フォームが崩れる不具合があったため修正いたしました。