### PR TITLE
デフォルトでゲストユーザーとしてログイン

### DIFF
--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -1,10 +1,13 @@
 class FriendsController < ApplicationController
   before_action :current_user
-  before_action :redirect_to_login
+  before_action :redirect_to_login, except: [:index]
   before_action :set_friend, only: [:show, :edit, :update, :destroy]
   before_action :set_friends_details, only: [:show]
 
   def index
+    if current_user.nil?
+      new_guest
+    end
     @friends = current_user.friends
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,13 +18,6 @@ class SessionsController < ApplicationController
   def destroy
     log_out if logged_in?
     flash[:success] = "ログアウトしました。"
-    redirect_to root_url
-  end
-
-  def new_guest
-    user = User.guest
-    log_in user
-    flash[:success] = "ゲストユーザーとしてログインしました。"
-    redirect_to friends_path
+    redirect_to login_url
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -51,4 +51,12 @@ module SessionsHelper
     session.delete(:user_id)
     @current_user = nil
   end
+
+  # ゲストユーザーとしてログイン
+  def new_guest
+    user = User.guest
+    log_in user
+    flash[:success] = "ゲストユーザーとしてログインしました。"
+    redirect_to friends_path
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root 'users#new'
+  root 'friends#index'
   get  '/signup',  to: 'users#new'
   post '/signup',  to: 'users#create'
 


### PR DESCRIPTION
使用者に登録の手間をかけさせないために、アプリを開いた時にデフォルトでゲストユーザーとしてログインするようにしました。
友達リストをルートURLにしています。

ログアウトしたときに「ゲストユーザーとしてログイン」をループさせないようにログインページにリダイレクトさせています。

new_guestメソッドをfriends_controller.rb で使うために、sessions_controller.rb からsessions_helper.rb にお引っ越しさせてあります。